### PR TITLE
moved hardcoded entry data to .json file for flexibility

### DIFF
--- a/api/entries.json
+++ b/api/entries.json
@@ -1,0 +1,32 @@
+{
+  "entries": [
+    {
+      "id": 1,
+      "date": "11/16/2020",
+      "concept": "HTML & CSS",
+      "entry": "We talked about HTML components and how to make grid layouts with Flexbox in CSS.",
+      "mood": "Ok"
+    },
+    {
+      "id": 2,
+      "date": "11/17/2020",
+      "concept": "Git and GitHub",
+      "entry": "We discussed using git and github",
+      "mood": "alright"
+    },
+    {
+      "id": 3,
+      "date": "11/18/2020",
+      "concept": "Java script basics",
+      "entry": "started in on using javascript",
+      "mood": "mind blown"
+    },
+    {
+      "id": 4,
+      "date": "11/19/2020",
+      "concept": "Filtering Source Data Into Smaller Arrays",
+      "entry": "Started out with a quick lightning excersise and then went straight into chapter 13 learning how to filter arrays using javascript",
+      "mood": "making it work!"
+    }
+  ]
+}

--- a/scripts/journalContent.js
+++ b/scripts/journalContent.js
@@ -1,13 +1,15 @@
-import { useJournalEntries } from "./journalDataProvider.js"
-import { journalEntry } from "./journalEntry.js"
+import { useJournalEntries, getJournalEntries } from "./journalDataProvider.js";
+import { journalEntry } from "./journalEntry.js";
+
+// refrence element to add code after
+const contentElement = document.querySelector(".journalContent");
 
 export const journalContent = () => {
-  // refrence element to add code after
-  const contentElement = document.querySelector(".journalContent");
-  const journalData = useJournalEntries()
-
-  for (const journalObject of journalData) {
-    const journalHTML = journalEntry(journalObject);
-    contentElement.innerHTML += journalHTML;
-  }
-}
+  getJournalEntries().then(() => {
+    let journalEntries = useJournalEntries();
+    for (const journalObject of journalEntries) {
+      const journalHTML = journalEntry(journalObject);
+      contentElement.innerHTML += journalHTML;
+    }
+  });
+};

--- a/scripts/journalDataProvider.js
+++ b/scripts/journalDataProvider.js
@@ -1,53 +1,22 @@
-/*
- *   Journal data provider for Daily Journal application
- *
- *      Holds the raw data about each entry and exports
- *      functions that other modules can use to filter
- *      the entries for different purposes.
- */
-
-// This is the original data.
-const journal = [
-  {
-    id: 1,
-    date: "11/16/2020",
-    concept: "HTML & CSS",
-    entry:
-      "We talked about HTML components and how to make grid layouts with Flexbox in CSS.",
-    mood: "Ok",
-  },
-  {
-    id: 2,
-    date: "11/17/2020",
-    concept: "Git and GitHub",
-    entry: "We discussed using git and github",
-    mood: "alright",
-  },
-  {
-    id: 3,
-    date: "11/18/2020",
-    concept: "Java script basics",
-    entry: "started in on using javascript",
-    mood: "mind blown",
-  },
-  {
-    id: 4,
-    date: "11/19/2020",
-    concept: "Filtering Source Data Into Smaller Arrays",
-    entry:
-      "Started out with a quick lightning excersise and then went straight into chapter 13 learning how to filter arrays using javascript",
-    mood: "making it work!",
-  },
-];
+// This is the original
+let journalEntries = [];
 
 /*
   You export a function that provides a version of the
   raw data in the format that you want
 */
 export const useJournalEntries = () => {
-  const sortedByDate = journal.sort(
+  const sortedByDate = journalEntries.sort(
     (currentEntry, nextEntry) =>
       Date.parse(currentEntry.date) - Date.parse(nextEntry.date)
   );
   return sortedByDate;
+};
+
+export const getJournalEntries = () => {
+  return fetch("http://localhost:8088/entries")
+    .then((response) => response.json())
+    .then((parsedJournalEntries) => {
+      journalEntries = parsedJournalEntries;
+    });
 };


### PR DESCRIPTION
## remove hardcoded data from journalDataProvider.js
Create entries.json to house the data for more functionality.
added getJournalEntries function to fetch the data from the json server.
called getJournalEntries on journalContent.js and refactored code to use the new data location.

## test
Data should render on the page as before.